### PR TITLE
Add stacked cubes and 3MF output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# objects
+# NLPrint3D
+
+NLPrint3D is a minimal proof-of-concept that converts very simple natural
+language descriptions into 3D objects ready for printing. The project parses
+text descriptions and generates basic shapes using `trimesh`.
+
+The CLI outputs `.3mf` files which can be loaded in slicers like OrcaSlicer or
+Bambu Studio.
+
+## Usage
+
+```bash
+# Create a cube with side length 2 and save as cube.3mf
+python -m nlprint3d.cli "cube with side 2" cube.3mf
+
+# Create three cubes stacked on top of each other and export to cubes.3mf
+python -m nlprint3d.cli "I want 3 cubes stacked on each other" cubes.3mf
+```
+
+Only a few shapes are supported in this MVP: cubes, spheres and cylinders.
+
+## Development
+
+Install dependencies and run the tests:
+
+```bash
+pip install -r requirements.txt
+python -m unittest discover -v tests
+```

--- a/nlprint3d/__init__.py
+++ b/nlprint3d/__init__.py
@@ -1,0 +1,7 @@
+"""Natural language to 3D printable object package."""
+
+__all__ = ["parse_description", "generate_mesh"]
+
+from .parser import parse_description
+from .generator import generate_mesh
+

--- a/nlprint3d/cli.py
+++ b/nlprint3d/cli.py
@@ -1,0 +1,31 @@
+"""Command-line interface for nlprint3d."""
+
+import argparse
+
+from . import parse_description, generate_mesh
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Generate 3D object from text")
+    parser.add_argument("description", help="Text description of the object")
+    parser.add_argument("output", help="Output 3MF file (must end with .3mf)")
+    args = parser.parse_args(argv)
+
+    if not args.output.lower().endswith(".3mf"):
+        parser.error("Output file must end with .3mf")
+
+    descs = parse_description(args.description)
+    if descs is None:
+        parser.error("Could not parse description")
+
+    mesh = generate_mesh(descs)
+    if mesh is None:
+        parser.error("Mesh generation failed (is trimesh installed?)")
+    mesh.export(args.output)
+    print(f"Wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+

--- a/nlprint3d/generator.py
+++ b/nlprint3d/generator.py
@@ -1,0 +1,69 @@
+"""Generate 3D meshes from shape descriptors."""
+
+from typing import Optional, List
+
+try:
+    import trimesh
+except ImportError:  # pragma: no cover - trimesh is optional for tests
+    trimesh = None
+
+from .parser import ShapeDescriptor
+
+
+def _generate_single_mesh(desc: ShapeDescriptor) -> Optional["trimesh.Trimesh"]:
+    """Create a mesh from a single :class:`ShapeDescriptor`.
+
+    Parameters
+    ----------
+    desc:
+        Shape descriptor describing the object.
+
+    Returns
+    -------
+    trimesh.Trimesh or ``None`` if trimesh is not available or the type is
+    unsupported.
+    """
+
+    if trimesh is None:
+        return None
+
+    if desc.type == "cube":
+        size = desc.params.get("size", 1)
+        return trimesh.creation.box((size, size, size))
+    if desc.type == "sphere":
+        radius = desc.params.get("radius", 1)
+        return trimesh.creation.icosphere(radius=radius)
+    if desc.type == "cylinder":
+        radius = desc.params.get("radius", 1)
+        height = desc.params.get("height", 1)
+        return trimesh.creation.cylinder(radius=radius, height=height)
+    return None
+
+
+def generate_mesh(descs: List[ShapeDescriptor]) -> Optional["trimesh.Trimesh"]:
+    """Create a mesh from a list of :class:`ShapeDescriptor` objects.
+
+    Parameters
+    ----------
+    descs:
+        List of shape descriptors describing the objects.
+
+    Returns
+    -------
+    trimesh.Trimesh or ``None`` if trimesh is not available or no meshes
+    could be created.
+    """
+    if trimesh is None:
+        return None
+
+    meshes = []
+    for d in descs:
+        m = _generate_single_mesh(d)
+        if m is not None:
+            m.apply_translation(d.position)
+            meshes.append(m)
+
+    if not meshes:
+        return None
+    return trimesh.util.concatenate(meshes)
+

--- a/nlprint3d/parser.py
+++ b/nlprint3d/parser.py
@@ -1,0 +1,58 @@
+"""Simple parser for converting natural language to shape descriptors."""
+
+import re
+from dataclasses import dataclass
+from typing import Optional, Dict, Any, List, Tuple
+
+
+@dataclass
+class ShapeDescriptor:
+    type: str
+    params: Dict[str, Any]
+    position: Tuple[float, float, float] = (0.0, 0.0, 0.0)
+
+
+_SHAPE_PATTERNS = [
+    (r"cube(?: with)? side (?P<size>\d+(?:\.\d+)?)", "cube"),
+    (r"sphere(?: with)? radius (?P<radius>\d+(?:\.\d+)?)", "sphere"),
+    (r"cylinder(?: with)? radius (?P<radius>\d+(?:\.\d+)?) height (?P<height>\d+(?:\.\d+)?)", "cylinder"),
+]
+
+
+def parse_description(text: str) -> Optional[List[ShapeDescriptor]]:
+    """Parse a simple text description into shape descriptors.
+
+    Parameters
+    ----------
+    text:
+        Natural language description of the object.
+
+    Returns
+    -------
+    list of :class:`ShapeDescriptor` or ``None`` if parsing failed.
+    """
+    text = text.lower().strip()
+
+    stacked = re.search(
+        r"(?P<count>\d+) cubes stacked(?: on (?:top of )?each other)?(?: with side (?P<size>\d+(?:\.\d+)?))?",
+        text,
+    )
+    if stacked:
+        count = int(stacked.group("count"))
+        size = float(stacked.group("size")) if stacked.group("size") else 1.0
+        return [
+            ShapeDescriptor(
+                type="cube",
+                params={"size": size},
+                position=(0.0, 0.0, i * size),
+            )
+            for i in range(count)
+        ]
+
+    for pattern, shape_type in _SHAPE_PATTERNS:
+        m = re.search(pattern, text)
+        if m:
+            params = {k: float(v) for k, v in m.groupdict().items()}
+            return [ShapeDescriptor(type=shape_type, params=params)]
+    return None
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+trimesh

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,17 @@
+import importlib
+import unittest
+from unittest import mock
+
+from nlprint3d.parser import ShapeDescriptor
+from nlprint3d import generator
+
+
+class GeneratorTests(unittest.TestCase):
+    def test_generate_mesh_without_trimesh(self):
+        with mock.patch.object(generator, "trimesh", None):
+            desc = [ShapeDescriptor(type="cube", params={"size": 1})]
+            self.assertIsNone(generator.generate_mesh(desc))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,26 @@
+import unittest
+
+from nlprint3d.parser import parse_description, ShapeDescriptor
+
+
+class ParserTests(unittest.TestCase):
+    def test_parse_cube(self):
+        desc = parse_description("cube with side 2")
+        self.assertEqual(desc, [ShapeDescriptor(type="cube", params={"size": 2.0})])
+
+    def test_parse_sphere(self):
+        desc = parse_description("sphere radius 4")
+        self.assertEqual(desc, [ShapeDescriptor(type="sphere", params={"radius": 4.0})])
+
+    def test_parse_stacked_cubes(self):
+        desc = parse_description("I want 3 cubes stacked on each other")
+        expected = [
+            ShapeDescriptor(type="cube", params={"size": 1.0}, position=(0.0, 0.0, 0.0)),
+            ShapeDescriptor(type="cube", params={"size": 1.0}, position=(0.0, 0.0, 1.0)),
+            ShapeDescriptor(type="cube", params={"size": 1.0}, position=(0.0, 0.0, 2.0)),
+        ]
+        self.assertEqual(desc, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow parser to recognize requests for multiple stacked cubes
- support positions in `ShapeDescriptor`
- generate meshes from multiple shapes and stack them
- enforce `.3mf` output in CLI and update README
- expand parser unit tests

## Testing
- `python -m unittest discover -v tests`