### PR TITLE
Enhance natural language generation with Shap-E fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# objects
+# NLPrint3D
+
+NLPrint3D is a minimal proof-of-concept that converts natural language
+descriptions into 3D objects ready for printing.  Simple shape descriptions
+are parsed directly, while arbitrary objects are passed through an optional
+generative model (Shap-E) if available.  The resulting mesh can be exported as
+an STL file for printing.
+
+## Usage
+
+```bash
+# Create a cube with side length 2 and save as cube.stl
+python -m nlprint3d.cli "cube with side 2" cube.stl
+```
+
+Only a few shapes are recognised by the built-in parser: cubes, spheres and
+cylinders.  Other requests fall back to the generative pipeline which requires
+the `shap_e` and `torch` packages.
+
+## Development
+
+Install dependencies and run the tests:
+
+```bash
+pip install -r requirements.txt
+python -m unittest discover -v tests
+```

--- a/nlprint3d/__init__.py
+++ b/nlprint3d/__init__.py
@@ -1,0 +1,8 @@
+"""Natural language to 3D printable object package."""
+
+__all__ = ["parse_description", "generate_mesh", "generate_from_text"]
+
+from .parser import parse_description
+from .generator import generate_mesh
+from .generative import generate_from_text
+

--- a/nlprint3d/cli.py
+++ b/nlprint3d/cli.py
@@ -1,0 +1,31 @@
+"""Command-line interface for nlprint3d."""
+
+import argparse
+
+from . import parse_description, generate_mesh, generate_from_text
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Generate 3D object from text")
+    parser.add_argument("description", help="Text description of the object")
+    parser.add_argument("output", help="Output STL file")
+    args = parser.parse_args(argv)
+
+    desc = parse_description(args.description)
+    if desc is not None:
+        mesh = generate_mesh(desc)
+    else:
+        mesh = generate_from_text(args.description)
+
+    if mesh is None:
+        parser.error(
+            "Mesh generation failed (unsupported description or missing dependencies)"
+        )
+    mesh.export(args.output)
+    print(f"Wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+

--- a/nlprint3d/generative.py
+++ b/nlprint3d/generative.py
@@ -1,0 +1,60 @@
+"""Generative mesh creation from natural language.
+
+This module provides a placeholder interface for creating meshes from
+arbitrary text descriptions using external models such as Shap-E.  The
+function returns ``None`` if the required libraries are unavailable.
+"""
+
+from typing import Optional
+import logging
+
+try:
+    import trimesh
+except ImportError:  # pragma: no cover - trimesh is optional
+    trimesh = None
+
+try:
+    import torch
+    from shap_e.diffusion.sample import sample_latents
+    from shap_e.diffusion.gaussian_diffusion import diffusion_from_config
+    from shap_e.util.notebooks import decode_latent_mesh
+    from shap_e.models.download import load_model
+    from shap_e.util import download
+except Exception:  # pragma: no cover - shap-e is optional
+    torch = None
+
+
+# Config paths used by Shap-E when installed
+CONFIG_NAME = "configs/image_and_text.json"
+MODEL_NAME = "text300M"
+
+
+def generate_from_text(text: str) -> Optional["trimesh.Trimesh"]:
+    """Attempt to generate a mesh from an arbitrary text description.
+
+    This is a thin wrapper around the Shap-E example pipeline. It requires
+    the ``shap_e`` package and ``torch``. If these dependencies are
+    unavailable, the function returns ``None``.
+    """
+    if torch is None or trimesh is None:
+        logging.warning("Generative dependencies not available")
+        return None
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    try:
+        model = load_model(MODEL_NAME, device)
+        diffusion = diffusion_from_config(download.get_config(CONFIG_NAME))
+        latents = sample_latents(
+            batch_size=1,
+            model=model,
+            diffusion=diffusion,
+            guidance_scale=15.0,
+            model_kwargs=dict(prompts=[text]),
+            progress=False,
+            device=device,
+        )
+        mesh = decode_latent_mesh(latents[0]).tri_mesh()
+        return mesh
+    except Exception as exc:  # pragma: no cover - runtime errors
+        logging.error("Generative model failed: %s", exc)
+        return None

--- a/nlprint3d/generator.py
+++ b/nlprint3d/generator.py
@@ -1,0 +1,40 @@
+"""Generate 3D meshes from shape descriptors."""
+
+from typing import Optional
+
+try:
+    import trimesh
+except ImportError:  # pragma: no cover - trimesh is optional for tests
+    trimesh = None
+
+from .parser import ShapeDescriptor
+
+
+def generate_mesh(desc: ShapeDescriptor) -> Optional["trimesh.Trimesh"]:
+    """Create a mesh from a :class:`ShapeDescriptor`.
+
+    Parameters
+    ----------
+    desc:
+        Shape descriptor describing the object.
+
+    Returns
+    -------
+    trimesh.Trimesh or ``None`` if trimesh is not available or the type is
+    unsupported.
+    """
+    if trimesh is None:
+        return None
+
+    if desc.type == "cube":
+        size = desc.params.get("size", 1)
+        return trimesh.creation.box((size, size, size))
+    if desc.type == "sphere":
+        radius = desc.params.get("radius", 1)
+        return trimesh.creation.icosphere(radius=radius)
+    if desc.type == "cylinder":
+        radius = desc.params.get("radius", 1)
+        height = desc.params.get("height", 1)
+        return trimesh.creation.cylinder(radius=radius, height=height)
+    return None
+

--- a/nlprint3d/parser.py
+++ b/nlprint3d/parser.py
@@ -1,0 +1,40 @@
+"""Simple parser for converting natural language to shape descriptors."""
+
+import re
+from dataclasses import dataclass
+from typing import Optional, Dict, Any
+
+
+@dataclass
+class ShapeDescriptor:
+    type: str
+    params: Dict[str, Any]
+
+
+_SHAPE_PATTERNS = [
+    (r"cube(?: with)? side (?P<size>\d+(?:\.\d+)?)", "cube"),
+    (r"sphere(?: with)? radius (?P<radius>\d+(?:\.\d+)?)", "sphere"),
+    (r"cylinder(?: with)? radius (?P<radius>\d+(?:\.\d+)?) height (?P<height>\d+(?:\.\d+)?)", "cylinder"),
+]
+
+
+def parse_description(text: str) -> Optional[ShapeDescriptor]:
+    """Parse a simple text description into a :class:`ShapeDescriptor`.
+
+    Parameters
+    ----------
+    text:
+        Natural language description of the object.
+
+    Returns
+    -------
+    ShapeDescriptor or ``None`` if parsing failed.
+    """
+    text = text.lower().strip()
+    for pattern, shape_type in _SHAPE_PATTERNS:
+        m = re.search(pattern, text)
+        if m:
+            params = {k: float(v) for k, v in m.groupdict().items()}
+            return ShapeDescriptor(type=shape_type, params=params)
+    return None
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+trimesh
+torch; extra == "generative"
+shap-e; extra == "generative"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,18 @@
+import unittest
+from unittest import mock
+
+import nlprint3d.cli as cli
+
+
+class CLITests(unittest.TestCase):
+    def test_fallback_to_generative(self):
+        mesh = mock.Mock()
+        with mock.patch.object(cli, "parse_description", return_value=None), \
+             mock.patch.object(cli, "generate_from_text", return_value=mesh), \
+             mock.patch.object(mesh, "export") as export:
+            cli.main(["something", "out.stl"])
+            export.assert_called_once_with("out.stl")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,17 @@
+import importlib
+import unittest
+from unittest import mock
+
+from nlprint3d.parser import ShapeDescriptor
+from nlprint3d import generator
+
+
+class GeneratorTests(unittest.TestCase):
+    def test_generate_mesh_without_trimesh(self):
+        with mock.patch.object(generator, "trimesh", None):
+            desc = ShapeDescriptor(type="cube", params={"size": 1})
+            self.assertIsNone(generator.generate_mesh(desc))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,20 @@
+import unittest
+
+from nlprint3d.parser import parse_description, ShapeDescriptor
+
+
+class ParserTests(unittest.TestCase):
+    def test_parse_cube(self):
+        desc = parse_description("cube with side 2")
+        self.assertEqual(desc, ShapeDescriptor(type="cube", params={"size": 2.0}))
+
+    def test_parse_sphere(self):
+        desc = parse_description("sphere radius 4")
+        self.assertEqual(desc, ShapeDescriptor(type="sphere", params={"radius": 4.0}))
+
+    def test_parse_unknown(self):
+        self.assertIsNone(parse_description("unrecognised object"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add optional generative pipeline using Shap-E
- expose new `generate_from_text` API
- fallback to generative model in CLI when parsing fails
- document generative support and requirements
- add CLI test and improve parser coverage

## Testing
- `python -m unittest discover -v tests`
